### PR TITLE
move Enum to top of namespace

### DIFF
--- a/sloth.ts
+++ b/sloth.ts
@@ -2,6 +2,26 @@
 //
 //% weight=5 color=#1BAFEA icon="\uf1b0"
 namespace sloth {
+
+    export enum PWMChn {
+        Right_Leg = 6,
+        Right_Foot = 7,
+        Left_Foot = 8,
+        Left_Leg = 9,
+        CH1 = 0,
+        CH2 = 1,
+        CH3 = 2,
+        CH4 = 3,
+        CH5 = 4,
+        CH6 = 5,
+        CH7 = 10,
+        CH8 = 11,
+        CH9 = 12,
+        CH10 = 13,
+        CH11 = 14,
+        CH12 = 15
+    }
+
     let right_leg = PWMChn.Right_Leg
     let right_foot = PWMChn.Right_Foot
     let left_foot = PWMChn.Left_Foot
@@ -25,24 +45,6 @@ namespace sloth {
     const ALL_LED_OFF_L = 0xFC
     const ALL_LED_OFF_H = 0xFD
 
-    export enum PWMChn {
-        Right_Leg = 6,
-        Right_Foot = 7,
-        Left_Foot = 8,
-        Left_Leg = 9,
-        CH1 = 0,
-        CH2 = 1,
-        CH3 = 2,
-        CH4 = 3,
-        CH5 = 4,
-        CH6 = 5,
-        CH7 = 10,
-        CH8 = 11,
-        CH9 = 12,
-        CH10 = 13,
-        CH11 = 14,
-        CH12 = 15
-    }
 
     let action_data = [
         [    // walk


### PR DESCRIPTION
Required to support TypeScript 2.0 compilation.